### PR TITLE
Fix warning about shadowing variable num_buckets

### DIFF
--- a/sparsehash/internal/densehashtable.h
+++ b/sparsehash/internal/densehashtable.h
@@ -490,8 +490,8 @@ class dense_hashtable {
   }
 
  private:
-  void fill_range_with_empty(pointer table_start, size_type num_buckets) {
-    for (size_type i = 0; i < num_buckets; ++i)
+  void fill_range_with_empty(pointer table_start, size_type count) {
+    for (size_type i = 0; i < count; ++i)
     {
       new(&table_start[i]) value_type();
       set_key(&table_start[i], key_info.empty_key);


### PR DESCRIPTION
Clang emits annoying warning about shadowing of `num_buckets` variable in `fill_range_with_empty` because `num_buckets` is a member of class and also an argument of a method.