### PR TITLE
Speedup dense_hashtable::fill_range_with_empty

### DIFF
--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -99,6 +99,7 @@
 #include <functional>  // for equal_to<>, select1st<>, etc
 #include <memory>      // for alloc
 #include <utility>     // for pair<>
+#include <tuple>       // forward_as_tuple
 #include <type_traits> // for enable_if, is_constructible, etc
 #include <sparsehash/internal/densehashtable.h>  // IWYU pragma: export
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
@@ -127,6 +128,9 @@ class dense_hash_map {
       // case it's taking up a lot of memory.  We do this by clearing
       // the value.  This assumes T has a zero-arg constructor!
       value->second = T();
+    }
+    void operator()(std::pair<const Key, T>* value, const Key& new_key, bool) const {
+      new(value) std::pair<const Key, T>(std::piecewise_construct, std::forward_as_tuple(new_key), std::forward_as_tuple());
     }
   };
   // The actual data

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -123,6 +123,9 @@ class dense_hash_set {
     void operator()(Value* value, const Value& new_key) const {
       *value = new_key;
     }
+    void operator()(Value* value, const Value& new_key, bool) const {
+        new(value) Value(new_key);
+    }
   };
 
   // The actual data

--- a/sparsehash/internal/densehashtable.h
+++ b/sparsehash/internal/densehashtable.h
@@ -493,8 +493,7 @@ class dense_hashtable {
   void fill_range_with_empty(pointer table_start, size_type count) {
     for (size_type i = 0; i < count; ++i)
     {
-      new(&table_start[i]) value_type();
-      set_key(&table_start[i], key_info.empty_key);
+      construct_key(&table_start[i], key_info.empty_key);
     }
   }
 
@@ -1283,6 +1282,9 @@ class dense_hashtable {
     void set_key(pointer v, const key_type& k) const {
       SetKey::operator()(v, k);
     }
+    void construct_key(pointer v, const key_type& k) const {
+      SetKey::operator()(v, k, true);
+    }
     bool equals(const key_type& a, const key_type& b) const {
       return EqualKey::operator()(a, b);
     }
@@ -1303,6 +1305,7 @@ class dense_hashtable {
     return key_info.get_key(std::forward<V>(v));
   }
   void set_key(pointer v, const key_type& k) const { key_info.set_key(v, k); }
+  void construct_key(pointer v, const key_type& k) const { key_info.construct_key(v, k); }
 
  private:
   // Actual data

--- a/tests/fixture_unittests.h
+++ b/tests/fixture_unittests.h
@@ -84,6 +84,10 @@ struct SetKey {
   void operator()(KeyAndValueT* value, const KeyAndValueT& new_key) const {
     *value = KeyToValue()(new_key);
   }
+  void operator()(KeyAndValueT* value, const KeyAndValueT& new_key, bool) const {
+    new (value) KeyAndValueT();
+    *value = KeyToValue()(new_key);
+  }
 };
 
 // A hash function that keeps track of how often it's called.  We use


### PR DESCRIPTION
`fill_range_with_empty` first construct a new element and then call `set_key`,
which, in turn, assign key and (for `dense_hash_map` case)
default-construct value part. It can be done more efficiently by
constructing container value just once, supplying empty key as an
argument. Any method doing resize benefits from this (i.e. insert).

To summarize:
for `dense_hash_set` it was 1 element construction and 1 assignment,
and became 1 element construction.
for `dense_hash_map` it was 1 element construction, 1 key assignment,
1 value construction, and became 1 element construction.
