### PR TITLE
Fix set_deleted_key to accomodate moveable-only map values

### DIFF
--- a/sparsehash/internal/densehashtable.h
+++ b/sparsehash/internal/densehashtable.h
@@ -375,7 +375,9 @@ class dense_hashtable {
  private:
   void squash_deleted() {          // gets rid of any deleted entries we have
     if (num_deleted) {             // get rid of deleted before writing
-      dense_hashtable tmp(*this);  // copying will get rid of deleted
+      size_type resize_to = settings.min_buckets(
+          num_elements, bucket_count());
+      dense_hashtable tmp(std::move(*this), resize_to);  // copying will get rid of deleted
       swap(tmp);                   // now we are tmp
     }
     assert(num_deleted == 0);

--- a/tests/hashtable_c11_unittests.cc
+++ b/tests/hashtable_c11_unittests.cc
@@ -23,6 +23,7 @@ TEST(DenseHashMapMoveTest, Insert_RValue)
 {
     dense_hash_map<int, std::unique_ptr<int>> h;
     h.set_empty_key(0);
+    h.set_deleted_key(-1);
 
     auto p1 = std::make_pair(5, make_unique<int>(1234));
     auto p = h.insert(std::move(p1));
@@ -42,6 +43,7 @@ TEST(DenseHashMapMoveTest, Emplace)
 {
     dense_hash_map<int, std::unique_ptr<int>> h;
     h.set_empty_key(0);
+    h.set_deleted_key(-1);
 
     auto p = h.emplace(5, make_unique<int>(1234));
     ASSERT_EQ(true, p.second);


### PR DESCRIPTION
dense_hash_map accepts moveable-only types as values, but method
set_deleted_key was incompatible with this due an oversight in
dense_hashtable::squash_deleted() method. This fix it and add
set_deleted_key to appropriate unit tests.