### PR TITLE
Add cbegin(i)/cend(i) methods for dense containers

### DIFF
--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -168,6 +168,8 @@ class dense_hash_map {
   local_iterator end(size_type i) { return rep.end(i); }
   const_local_iterator begin(size_type i) const { return rep.begin(i); }
   const_local_iterator end(size_type i) const { return rep.end(i); }
+  const_local_iterator cbegin(size_type i) const { return rep.begin(i); }
+  const_local_iterator cend(size_type i) const { return rep.end(i); }
 
   // Accessor functions
   allocator_type get_allocator() const { return rep.get_allocator(); }

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -158,6 +158,8 @@ class dense_hash_set {
   // These come from tr1's unordered_set. For us, a bucket has 0 or 1 elements.
   local_iterator begin(size_type i) const { return rep.begin(i); }
   local_iterator end(size_type i) const { return rep.end(i); }
+  local_iterator cbegin(size_type i) const { return rep.begin(i); }
+  local_iterator cend(size_type i) const { return rep.end(i); }
 
   // Accessor functions
   allocator_type get_allocator() const { return rep.get_allocator(); }

--- a/tests/hashtable_c11_unittests.cc
+++ b/tests/hashtable_c11_unittests.cc
@@ -437,6 +437,66 @@ TEST(DenseHashMapMoveTest, CBeginCEnd)
     ASSERT_TRUE(end == h.cend());
 }
 
+TEST(DenseHashSetIfaceTest, BucketBeginEnd)
+{
+    dense_hash_set<int> h;
+    h.set_empty_key(0);
+    h.set_deleted_key(-1);
+
+    EXPECT_TRUE(h.begin(0) == h.end(0)) << "empty set";
+    EXPECT_TRUE(h.begin(10) == h.end(10)) << "empty set";
+    EXPECT_TRUE(h.cbegin(0) == h.cend(0)) << "empty set";
+    EXPECT_TRUE(h.cbegin(10) == h.cend(10)) << "empty set";
+
+    h.insert(1);
+    const auto n1 = h.bucket(1);
+    EXPECT_FALSE(h.begin(n1) == h.end(n1)) << "singleton set";
+    EXPECT_EQ(1, std::distance(h.begin(n1), h.end(n1))) << "singleton set";
+    EXPECT_FALSE(h.cbegin(n1) == h.cend(n1)) << "singleton set";
+    EXPECT_EQ(1, *h.cbegin(n1)) << "singleton set";
+
+    h.insert(2);
+    const auto n2 = h.bucket(2);
+    EXPECT_FALSE(h.begin(n1) == h.end(n1)) << "two elements set";
+    EXPECT_EQ(1, std::distance(h.begin(n1), h.end(n1))) << "two elements set";
+    EXPECT_FALSE(h.begin(n2) == h.end(n2)) << "two elements set";
+    EXPECT_EQ(1, std::distance(h.begin(n2), h.end(n2))) << "two elements set";
+    EXPECT_EQ(1, std::distance(h.cbegin(n1), h.cend(n1))) << "two elements set";
+    EXPECT_EQ(1, std::distance(h.cbegin(n2), h.cend(n2))) << "two elements set";
+    EXPECT_EQ(1, *h.cbegin(n1)) << "two elements set";
+    EXPECT_EQ(2, *h.cbegin(n2)) << "two elements set";
+}
+
+TEST(DenseHashMapIfaceTest, BucketBeginEnd)
+{
+    dense_hash_map<int, int> h;
+    h.set_empty_key(0);
+    h.set_deleted_key(-1);
+
+    EXPECT_TRUE(h.begin(0) == h.end(0)) << "empty map";
+    EXPECT_TRUE(h.begin(10) == h.end(10)) << "empty map";
+    EXPECT_TRUE(h.cbegin(0) == h.cend(0)) << "empty map";
+    EXPECT_TRUE(h.cbegin(10) == h.cend(10)) << "empty map";
+
+    h.emplace(1, 10);
+    const auto n1 = h.bucket(1);
+    EXPECT_FALSE(h.begin(n1) == h.end(n1)) << "singleton map";
+    EXPECT_EQ(1, std::distance(h.begin(n1), h.end(n1))) << "singleton map";
+    EXPECT_FALSE(h.cbegin(n1) == h.cend(n1)) << "singleton map";
+    EXPECT_EQ(10, h.cbegin(n1)->second) << "singleton map";
+
+    h.emplace(2, 20);
+    const auto n2 = h.bucket(2);
+    EXPECT_FALSE(h.begin(n1) == h.end(n1)) << "two elements map";
+    EXPECT_EQ(1, std::distance(h.begin(n1), h.end(n1))) << "two elements map";
+    EXPECT_FALSE(h.begin(n2) == h.end(n2)) << "two elements map";
+    EXPECT_EQ(1, std::distance(h.begin(n2), h.end(n2))) << "two elements map";
+    EXPECT_EQ(1, std::distance(h.cbegin(n1), h.cend(n1))) << "two elements map";
+    EXPECT_EQ(1, std::distance(h.cbegin(n2), h.cend(n2))) << "two elements map";
+    EXPECT_EQ(10, h.cbegin(n1)->second) << "two elements map";
+    EXPECT_EQ(20, h.cbegin(n2)->second) << "two elements map";
+}
+
 TEST(DenseHashSetMoveTest, MoveConstructor)
 {
     dense_hash_set<A, HashA> h;


### PR DESCRIPTION
Add bucket interface methods cbegin(size_type)/cend(size_type) which std unordered containers have to dense_hash_set/dense_hash_map.