### PR TITLE
Add missing insert method for dense containers

### DIFF
--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -97,6 +97,7 @@
 
 #include <algorithm>   // needed by stl_alloc
 #include <functional>  // for equal_to<>, select1st<>, etc
+#include <initializer_list> // for initializer_list
 #include <memory>      // for alloc
 #include <utility>     // for pair<>
 #include <type_traits> // for enable_if, is_constructible, etc
@@ -301,6 +302,7 @@ class dense_hash_map {
     rep.insert(f, l);
   }
   void insert(const_iterator f, const_iterator l) { rep.insert(f, l); }
+  void insert(std::initializer_list<value_type> ilist) { rep.insert(ilist.begin(), ilist.end()); }
   // Required for std::insert_iterator; the passed-in iterator is ignored.
   iterator insert(iterator, const value_type& obj) { return insert(obj).first; }
 

--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -304,7 +304,13 @@ class dense_hash_map {
   void insert(const_iterator f, const_iterator l) { rep.insert(f, l); }
   void insert(std::initializer_list<value_type> ilist) { rep.insert(ilist.begin(), ilist.end()); }
   // Required for std::insert_iterator; the passed-in iterator is ignored.
-  iterator insert(iterator, const value_type& obj) { return insert(obj).first; }
+  iterator insert(const_iterator, const value_type& obj) { return insert(obj).first; }
+  iterator insert(const_iterator, value_type&& obj) { return insert(std::move(obj)).first; }
+  template <class P, class = typename std::enable_if<
+                                        std::is_constructible<value_type, P&&>::value &&
+                                        !std::is_same<value_type, P>::value
+                                      >::type>
+  iterator insert(const_iterator, P&& obj) { return insert(std::forward<P>(obj)).first; }
 
   // Deletion and empty routines
   // THESE ARE NON-STANDARD!  I make you specify an "impossible" key

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -101,6 +101,7 @@
 
 #include <algorithm>   // needed by stl_alloc
 #include <functional>  // for equal_to<>, select1st<>, etc
+#include <initializer_list> // for initializer_list
 #include <memory>      // for alloc
 #include <utility>     // for pair<>
 #include <sparsehash/internal/densehashtable.h>  // IWYU pragma: export
@@ -269,6 +270,7 @@ class dense_hash_set {
     rep.insert(f, l);
   }
   void insert(const_iterator f, const_iterator l) { rep.insert(f, l); }
+  void insert(std::initializer_list<value_type> ilist) { rep.insert(ilist.begin(), ilist.end()); }
   // Required for std::insert_iterator; the passed-in iterator is ignored.
   iterator insert(iterator, const value_type& obj) { return insert(obj).first; }
 

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -272,7 +272,8 @@ class dense_hash_set {
   void insert(const_iterator f, const_iterator l) { rep.insert(f, l); }
   void insert(std::initializer_list<value_type> ilist) { rep.insert(ilist.begin(), ilist.end()); }
   // Required for std::insert_iterator; the passed-in iterator is ignored.
-  iterator insert(iterator, const value_type& obj) { return insert(obj).first; }
+  iterator insert(const_iterator, const value_type& obj) { return insert(obj).first; }
+  iterator insert(const_iterator, value_type&& obj) { return insert(std::move(obj)).first; }
 
   // Deletion and empty routines
   // THESE ARE NON-STANDARD!  I make you specify an "impossible" key

--- a/tests/hashtable_c11_unittests.cc
+++ b/tests/hashtable_c11_unittests.cc
@@ -504,3 +504,40 @@ TEST(DenseHashSetMoveTest, Emplace)
     ASSERT_EQ(0, A::move_ctor);
     ASSERT_EQ(0, A::move_assign);
 }
+
+TEST(DenseHashSetIfaceTest, Insert)
+{
+    dense_hash_set<int> h;
+    h.set_empty_key(0);
+
+    const int k1 = 10;
+    int k2 = 20;
+    std::vector<int> v { 5, 15, 25, 35 };
+
+    EXPECT_TRUE(h.insert(k1).second);
+    EXPECT_TRUE(h.insert(k2).second);
+    h.insert(h.begin(), 2);
+    h.insert(h.begin(), std::move(3));
+    h.insert(v.begin(), v.end());
+    h.insert({11, 21, 31});
+    EXPECT_EQ(11, h.size());
+}
+
+TEST(DenseHashMapIfaceTest, Insert)
+{
+    dense_hash_map<int, int> h;
+    h.set_empty_key(0);
+
+    const std::pair<const int, int> k1 { 10, 100 };
+    std::pair<const int, int> k2 { 20, 200 };
+    const std::pair<const int, int> k3 { 30, 300 };
+    std::vector<std::pair<const int, int>> v { {5, 50}, {15, 150} };
+
+    EXPECT_TRUE(h.insert(k1).second);
+    EXPECT_TRUE(h.insert(k2).second);
+    h.insert(h.begin(), k3);
+    h.insert(h.begin(), std::pair<const int, int>{2, 20});
+    h.insert(v.begin(), v.end());
+    h.insert({{11, 110}, {21, 210}, {31, 310}});
+    EXPECT_EQ(9, h.size());
+}


### PR DESCRIPTION
Add insert(std::initializer_list<value_type>) overload for dense_hash_set/dense_hash_map, because std unordered containers have such overload.