### PR TITLE
Add compatibily for gcc 4.x in traits

### DIFF
--- a/sparsehash/traits
+++ b/sparsehash/traits
@@ -40,10 +40,20 @@ namespace google {
 // struct is_relocatable<MyType> : std::true_type {};
 // }
 
+// Work around lack of std::is_trivially_copy_constructible in gcc 4.x by
+// aliasing it to has_trivial_copy_constructor in those versions.
+#if ! __clang__ && __GNUC__ < 5
+template<class T>
+using is_trivially_copy_constructible = std::has_trivial_copy_constructor<T>;
+#else
+template<typename T>
+using is_trivially_copy_constructible = std::is_trivially_copy_constructible<T>;
+#endif
+
 template <class T>
 struct is_relocatable
     : std::integral_constant<bool,
-                             (std::is_trivially_copy_constructible<T>::value &&
+                             (is_trivially_copy_constructible<T>::value &&
                               std::is_trivially_destructible<T>::value)> {};
 template <class T, class U>
 struct is_relocatable<std::pair<T, U>>


### PR DESCRIPTION
gcc 4.x doesn't implement std::is_trivially_copy_constructible<>. For
these versions, we should fall back to std::has_trivial_copy_constructor<>

Tested by building a small test using gcc 4.8, gcc 5.4, and clang 3.9.