### PR TITLE
Support heterogeneous lookup (P0919R3)

### DIFF
--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -134,10 +134,17 @@ class dense_hash_map {
       new(value) std::pair<const Key, T>(std::piecewise_construct, std::forward_as_tuple(new_key), std::forward_as_tuple());
     }
   };
+
   // The actual data
+  typedef typename sparsehash_internal::key_equal_chosen<HashFcn, EqualKey>::type EqualKeyChosen;
   typedef dense_hashtable<std::pair<const Key, T>, Key, HashFcn, SelectKey,
-                          SetKey, EqualKey, Alloc> ht;
+                          SetKey, EqualKeyChosen, Alloc> ht;
   ht rep;
+
+  static_assert(!sparsehash_internal::has_transparent_key_equal<HashFcn>::value
+                || std::is_same<EqualKey, std::equal_to<Key>>::value
+                || std::is_same<EqualKey, EqualKeyChosen>::value,
+                "Heterogeneous lookup requires key_equal to either be the default container value or the same as the type provided by hash");
 
  public:
   typedef typename ht::key_type key_type;
@@ -256,6 +263,13 @@ class dense_hash_map {
   iterator find(const key_type& key) { return rep.find(key); }
   const_iterator find(const key_type& key) const { return rep.find(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, iterator>::type
+  find(const K& key) { return rep.find(key); }
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, const_iterator>::type
+  find(const K& key) const { return rep.find(key); }
+
   data_type& operator[](const key_type& key) {  // This is our value-add!
     // If key is in the hashtable, returns find(key)->second,
     // otherwise returns insert(value_type(key, T()).first->second.
@@ -269,11 +283,26 @@ class dense_hash_map {
 
   size_type count(const key_type& key) const { return rep.count(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, size_type>::type
+  count(const K& key) const { return rep.count(key); }
+
   std::pair<iterator, iterator> equal_range(const key_type& key) {
     return rep.equal_range(key);
   }
   std::pair<const_iterator, const_iterator> equal_range(
       const key_type& key) const {
+    return rep.equal_range(key);
+  }
+
+  template<typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<iterator, iterator>>::type
+  equal_range(const K& key) {
+    return rep.equal_range(key);
+  }
+  template<typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<const_iterator, const_iterator>>::type
+  equal_range(const K& key) const {
     return rep.equal_range(key);
   }
 

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -130,9 +130,15 @@ class dense_hash_set {
   };
 
   // The actual data
-  typedef dense_hashtable<Value, Value, HashFcn, Identity, SetKey, EqualKey,
+  typedef typename sparsehash_internal::key_equal_chosen<HashFcn, EqualKey>::type EqualKeyChosen;
+  typedef dense_hashtable<Value, Value, HashFcn, Identity, SetKey, EqualKeyChosen,
                           Alloc> ht;
   ht rep;
+
+  static_assert(!sparsehash_internal::has_transparent_key_equal<HashFcn>::value
+                || std::is_same<EqualKey, std::equal_to<Value>>::value
+                || std::is_same<EqualKey, EqualKeyChosen>::value,
+                "Heterogeneous lookup requires key_equal to either be the default container value or the same as the type provided by hash");
 
  public:
   typedef typename ht::key_type key_type;
@@ -243,9 +249,23 @@ class dense_hash_set {
   // Lookup routines
   iterator find(const key_type& key) const { return rep.find(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, iterator>::type
+  find(const K& key) const { return rep.find(key); }
+
   size_type count(const key_type& key) const { return rep.count(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, size_type>::type
+  count(const K& key) const { return rep.count(key); }
+
   std::pair<iterator, iterator> equal_range(const key_type& key) const {
+    return rep.equal_range(key);
+  }
+
+  template<typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<iterator, iterator>>::type
+  equal_range(const K& key) const {
     return rep.equal_range(key);
   }
 

--- a/sparsehash/internal/densehashtable.h
+++ b/sparsehash/internal/densehashtable.h
@@ -862,7 +862,8 @@ class dense_hashtable {
   // if object is not found; 2nd is ILLEGAL_BUCKET if it is.
   // Note: because of deletions where-to-insert is not trivial: it's the
   // first deleted bucket we see, as long as we don't find the key later
-  std::pair<size_type, size_type> find_position(const key_type& key) const {
+  template <typename K>
+  std::pair<size_type, size_type> find_position(const K& key) const {
     size_type num_probes = 0;  // how many times we've probed
     const size_type bucket_count_minus_one = bucket_count() - 1;
     size_type bucknum = hash(key) & bucket_count_minus_one;
@@ -888,7 +889,8 @@ class dense_hashtable {
   }
 
  public:
-  iterator find(const key_type& key) {
+  template <typename K>
+  iterator find(const K& key) {
     if (size() == 0) return end();
     std::pair<size_type, size_type> pos = find_position(key);
     if (pos.first == ILLEGAL_BUCKET)  // alas, not there
@@ -897,7 +899,8 @@ class dense_hashtable {
       return iterator(this, table + pos.first, table + num_buckets, false);
   }
 
-  const_iterator find(const key_type& key) const {
+  template <typename K>
+  const_iterator find(const K& key) const {
     if (size() == 0) return end();
     std::pair<size_type, size_type> pos = find_position(key);
     if (pos.first == ILLEGAL_BUCKET)  // alas, not there
@@ -915,13 +918,15 @@ class dense_hashtable {
   }
 
   // Counts how many elements have key key.  For maps, it's either 0 or 1.
-  size_type count(const key_type& key) const {
+  template <typename K>
+  size_type count(const K& key) const {
     std::pair<size_type, size_type> pos = find_position(key);
     return pos.first == ILLEGAL_BUCKET ? 0 : 1;
   }
 
   // Likewise, equal_range doesn't really make sense for us.  Oh well.
-  std::pair<iterator, iterator> equal_range(const key_type& key) {
+  template <typename K>
+  std::pair<iterator, iterator> equal_range(const K& key) {
     iterator pos = find(key);  // either an iterator or end
     if (pos == end()) {
       return std::pair<iterator, iterator>(pos, pos);
@@ -930,8 +935,9 @@ class dense_hashtable {
       return std::pair<iterator, iterator>(startpos, pos);
     }
   }
+  template <typename K>
   std::pair<const_iterator, const_iterator> equal_range(
-      const key_type& key) const {
+      const K& key) const {
     const_iterator pos = find(key);  // either an iterator or end
     if (pos == end()) {
       return std::pair<const_iterator, const_iterator>(pos, pos);
@@ -1287,7 +1293,8 @@ class dense_hashtable {
     void construct_key(pointer v, const key_type& k) const {
       SetKey::operator()(v, k, true);
     }
-    bool equals(const key_type& a, const key_type& b) const {
+    template <typename K1, typename K2>
+    bool equals(const K1& a, const K2& b) const {
       return EqualKey::operator()(a, b);
     }
 
@@ -1298,8 +1305,10 @@ class dense_hashtable {
   };
 
   // Utility functions to access the templated operators
-  size_type hash(const key_type& v) const { return settings.hash(v); }
-  bool equals(const key_type& a, const key_type& b) const {
+  template <typename K>
+  size_type hash(const K& v) const { return settings.hash(v); }
+  template <typename K1, typename K2>
+  bool equals(const K1& a, const K2& b) const {
     return key_info.equals(a, b);
   }
   template <typename V>

--- a/sparsehash/internal/sparsehashtable.h
+++ b/sparsehash/internal/sparsehashtable.h
@@ -860,7 +860,8 @@ class sparse_hashtable {
   // if object is not found; 2nd is ILLEGAL_BUCKET if it is.
   // Note: because of deletions where-to-insert is not trivial: it's the
   // first deleted bucket we see, as long as we don't find the key later
-  std::pair<size_type, size_type> find_position(const key_type& key) const {
+  template <typename K>
+  std::pair<size_type, size_type> find_position(const K& key) const {
     size_type num_probes = 0;  // how many times we've probed
     const size_type bucket_count_minus_one = bucket_count() - 1;
     size_type bucknum = hash(key) & bucket_count_minus_one;
@@ -887,7 +888,8 @@ class sparse_hashtable {
   }
 
  public:
-  iterator find(const key_type& key) {
+  template <typename K>
+  iterator find(const K& key) {
     if (size() == 0) return end();
     std::pair<size_type, size_type> pos = find_position(key);
     if (pos.first == ILLEGAL_BUCKET)  // alas, not there
@@ -896,7 +898,8 @@ class sparse_hashtable {
       return iterator(this, table.get_iter(pos.first), table.nonempty_end());
   }
 
-  const_iterator find(const key_type& key) const {
+  template <typename K>
+  const_iterator find(const K& key) const {
     if (size() == 0) return end();
     std::pair<size_type, size_type> pos = find_position(key);
     if (pos.first == ILLEGAL_BUCKET)  // alas, not there
@@ -914,13 +917,15 @@ class sparse_hashtable {
   }
 
   // Counts how many elements have key key.  For maps, it's either 0 or 1.
-  size_type count(const key_type& key) const {
+  template <typename K>
+  size_type count(const K& key) const {
     std::pair<size_type, size_type> pos = find_position(key);
     return pos.first == ILLEGAL_BUCKET ? 0 : 1;
   }
 
   // Likewise, equal_range doesn't really make sense for us.  Oh well.
-  std::pair<iterator, iterator> equal_range(const key_type& key) {
+  template <typename K>
+  std::pair<iterator, iterator> equal_range(const K& key) {
     iterator pos = find(key);  // either an iterator or end
     if (pos == end()) {
       return std::pair<iterator, iterator>(pos, pos);
@@ -929,8 +934,9 @@ class sparse_hashtable {
       return std::pair<iterator, iterator>(startpos, pos);
     }
   }
+  template <typename K>
   std::pair<const_iterator, const_iterator> equal_range(
-      const key_type& key) const {
+      const K& key) const {
     const_iterator pos = find(key);  // either an iterator or end
     if (pos == end()) {
       return std::pair<const_iterator, const_iterator>(pos, pos);
@@ -1201,7 +1207,8 @@ class sparse_hashtable {
     void set_key(pointer v, const key_type& k) const {
       SetKey::operator()(v, k);
     }
-    bool equals(const key_type& a, const key_type& b) const {
+    template <typename K1, typename K2>
+    bool equals(const K1& a, const K2& b) const {
       return EqualKey::operator()(a, b);
     }
 
@@ -1212,8 +1219,10 @@ class sparse_hashtable {
   };
 
   // Utility functions to access the templated operators
-  size_type hash(const key_type& v) const { return settings.hash(v); }
-  bool equals(const key_type& a, const key_type& b) const {
+  template <typename K>
+  size_type hash(const K& v) const { return settings.hash(v); }
+  template <typename K1, typename K2>
+  bool equals(const K1& a, const K2& b) const {
     return key_info.equals(a, b);
   }
   typename ExtractKey::result_type get_key(const_reference v) const {

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -121,9 +121,15 @@ class sparse_hash_map {
   };
 
   // The actual data
+  typedef typename sparsehash_internal::key_equal_chosen<HashFcn, EqualKey>::type EqualKeyChosen;
   typedef sparse_hashtable<std::pair<const Key, T>, Key, HashFcn, SelectKey,
-                           SetKey, EqualKey, Alloc> ht;
+                           SetKey, EqualKeyChosen, Alloc> ht;
   ht rep;
+
+  static_assert(!sparsehash_internal::has_transparent_key_equal<HashFcn>::value
+                || std::is_same<EqualKey, std::equal_to<Key>>::value
+                || std::is_same<EqualKey, EqualKeyChosen>::value,
+                "Heterogeneous lookup requires key_equal to either be the default container value or the same as the type provided by hash");
 
  public:
   typedef typename ht::key_type key_type;
@@ -233,6 +239,13 @@ class sparse_hash_map {
   iterator find(const key_type& key) { return rep.find(key); }
   const_iterator find(const key_type& key) const { return rep.find(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, iterator>::type
+  find(const K& key) { return rep.find(key); }
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, const_iterator>::type
+  find(const K& key) const { return rep.find(key); }
+
   data_type& operator[](const key_type& key) {  // This is our value-add!
     // If key is in the hashtable, returns find(key)->second,
     // otherwise returns insert(value_type(key, T()).first->second.
@@ -242,11 +255,26 @@ class sparse_hash_map {
 
   size_type count(const key_type& key) const { return rep.count(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, size_type>::type
+  count(const K& key) const { return rep.count(key); }
+
   std::pair<iterator, iterator> equal_range(const key_type& key) {
     return rep.equal_range(key);
   }
   std::pair<const_iterator, const_iterator> equal_range(
       const key_type& key) const {
+    return rep.equal_range(key);
+  }
+
+  template<typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<iterator, iterator>>::type
+  equal_range(const K& key) {
+    return rep.equal_range(key);
+  }
+  template<typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<const_iterator, const_iterator>>::type
+  equal_range(const K& key) const {
     return rep.equal_range(key);
   }
 

--- a/sparsehash/sparse_hash_set
+++ b/sparsehash/sparse_hash_set
@@ -112,9 +112,15 @@ class sparse_hash_set {
     }
   };
 
-  typedef sparse_hashtable<Value, Value, HashFcn, Identity, SetKey, EqualKey,
+  typedef typename sparsehash_internal::key_equal_chosen<HashFcn, EqualKey>::type EqualKeyChosen;
+  typedef sparse_hashtable<Value, Value, HashFcn, Identity, SetKey, EqualKeyChosen,
                            Alloc> ht;
   ht rep;
+
+  static_assert(!sparsehash_internal::has_transparent_key_equal<HashFcn>::value
+                || std::is_same<EqualKey, std::equal_to<Value>>::value
+                || std::is_same<EqualKey, EqualKeyChosen>::value,
+                "Heterogeneous lookup requires key_equal to either be the default container value or the same as the type provided by hash");
 
  public:
   typedef typename ht::key_type key_type;
@@ -216,9 +222,23 @@ class sparse_hash_set {
   // Lookup routines
   iterator find(const key_type& key) const { return rep.find(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, iterator>::type
+  find(const K& key) const { return rep.find(key); }
+
   size_type count(const key_type& key) const { return rep.count(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, size_type>::type
+  count(const K& key) const { return rep.count(key); }
+
   std::pair<iterator, iterator> equal_range(const key_type& key) const {
+    return rep.equal_range(key);
+  }
+
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<iterator, iterator>>::type
+  equal_range(const K& key) const {
     return rep.equal_range(key);
   }
 

--- a/tests/fixture_unittests.cc
+++ b/tests/fixture_unittests.cc
@@ -15,6 +15,8 @@ const int kEmptyInt = 0;
 const int kDeletedInt = -1234676543;  // an unlikely-to-pick int
 const char* const kEmptyCharStar = "--empty char*--";
 const char* const kDeletedCharStar = "--deleted char*--";
+const pair<int, int> kEmptyIntPair = {0, 0};
+const pair<int, int> kDeletedIntPair = {-1234676543, -1234676543};
 
 const char* const ValueType::kDefault = "hi";
 
@@ -75,4 +77,16 @@ pair<const char* const, ValueType> UniqueObjectHelper(int index) {
   return pair<const char* const, ValueType>(
       UniqueObjectHelper<char*>(index),
       UniqueObjectHelper<ValueType>(index + 1));
+}
+
+template <>
+pair<int, int> UniqueObjectHelper(int index) {
+  return pair<int, int>(index, index + 1);
+}
+
+template <>
+pair<const pair<int, int>, int> UniqueObjectHelper(int index) {
+  return pair<const pair<int, int>, int>(
+      UniqueObjectHelper<pair<int, int>>(index),
+      index + 2);
 }

--- a/tests/hashtable_test_interface.h
+++ b/tests/hashtable_test_interface.h
@@ -223,6 +223,13 @@ class BaseHashtableInterface {
     return const_iterator(ht_.find(key), this);
   }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, iterator>::type
+  find(const K& key) { return iterator(ht_.find(key), this); }
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, const_iterator>::type
+  find(const K& key) const { return const_iterator(ht_.find(key), this); }
+
   // Rather than try to implement operator[], which doesn't make much
   // sense for set types, we implement two methods: bracket_equal and
   // bracket_assign.  By default, bracket_equal(a, b) returns true if
@@ -245,6 +252,10 @@ class BaseHashtableInterface {
 
   size_type count(const key_type& key) const { return ht_.count(key); }
 
+  template <typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, size_type>::type
+  count(const K& key) const { return ht_.count(key); }
+
   std::pair<iterator, iterator> equal_range(const key_type& key) {
     std::pair<typename HT::iterator, typename HT::iterator> r =
         ht_.equal_range(key);
@@ -253,6 +264,24 @@ class BaseHashtableInterface {
   }
   std::pair<const_iterator, const_iterator> equal_range(
       const key_type& key) const {
+    std::pair<typename HT::const_iterator, typename HT::const_iterator> r =
+        ht_.equal_range(key);
+    return std::pair<const_iterator, const_iterator>(
+        const_iterator(r.first, this), const_iterator(r.second, this));
+  }
+
+  template<typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<iterator, iterator>>::type
+  equal_range(const K& key) {
+    std::pair<typename HT::iterator, typename HT::iterator> r =
+        ht_.equal_range(key);
+    return std::pair<iterator, iterator>(iterator(r.first, this),
+                                         iterator(r.second, this));
+  }
+  template<typename K>
+  typename std::enable_if<sparsehash_internal::has_transparent_key_equal<hasher, K>::value, std::pair<const_iterator, const_iterator>>::type
+  equal_range(
+      const K& key) const {
     std::pair<typename HT::const_iterator, typename HT::const_iterator> r =
         ht_.equal_range(key);
     return std::pair<const_iterator, const_iterator>(


### PR DESCRIPTION
C++20 (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0919r3.html) will be supporting heterogeneous lookup for `find`, `count` and `equal_range` for `unordered_set` and `unordered_map`.

This PR implements the analogous changes in `dense_hash_set`, `dense_hash_map`, `sparse_hash_set` and `sparse_hash_map` to keep up with the functionality of C++20. This will improve the containers' performance when key construction is costly or impractical.