### PR TITLE
Add reserve(size) method

### DIFF
--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -256,6 +256,7 @@ class dense_hash_map {
     rep.set_resizing_parameters(shrink, grow);
   }
 
+  void reserve(size_type size) { rehash(size); } // note: rehash internally treats hint/size as number of elements
   void resize(size_type hint) { rep.resize(hint); }
   void rehash(size_type hint) { resize(hint); }  // the tr1 name
 

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -243,6 +243,7 @@ class dense_hash_set {
     rep.set_resizing_parameters(shrink, grow);
   }
 
+  void reserve(size_type size) { rehash(size); } // note: rehash internally treats hint/size as number of elements
   void resize(size_type hint) { rep.resize(hint); }
   void rehash(size_type hint) { resize(hint); }  // the tr1 name
 

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -232,6 +232,7 @@ class sparse_hash_map {
     rep.set_resizing_parameters(shrink, grow);
   }
 
+  void reserve(size_type size) { rehash(size); } // note: rehash internally treats hint/size as number of elements
   void resize(size_type hint) { rep.resize(hint); }
   void rehash(size_type hint) { resize(hint); }  // the tr1 name
 

--- a/sparsehash/sparse_hash_set
+++ b/sparsehash/sparse_hash_set
@@ -216,6 +216,7 @@ class sparse_hash_set {
     rep.set_resizing_parameters(shrink, grow);
   }
 
+  void reserve(size_type size) { rehash(size); } // note: rehash internally treats hint/size as number of elements
   void resize(size_type hint) { rep.resize(hint); }
   void rehash(size_type hint) { resize(hint); }  // the tr1 name
 


### PR DESCRIPTION
Normally reserve(size) might be implemented as rehash(std::ceil(size / max_load_factor())), however, this implementation calls rehash(size) as rehash internally treats hint/size as number of elements instead of buckets