### PR TITLE
dense_hash_map: add try_emplace method

### DIFF
--- a/docs/dense_hash_map.html
+++ b/docs/dense_hash_map.html
@@ -1132,6 +1132,70 @@ pair&lt;iterator, bool&gt; emplace_hint(const_iterator hint, Args&amp;&amp;... a
 
 <TR>
 <TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(const key_type&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>dense_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>dense_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(key_type&amp;&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>dense_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>dense_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(const_iterator hint, const key_type&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>dense_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>dense_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(const_iterator hint, key_type&amp;&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>dense_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>dense_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
    <tt>void set_empty_key(const key_type& key)</tt> <A href="#6">[6]</A>
 </TD>
 <TD VAlign=top>

--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -341,6 +341,25 @@ class dense_hash_map {
     return rep.emplace_hint(hint, std::forward<Args>(args)...);
   }
 
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const key_type& k, Args&&... args) {
+    return rep.try_emplace(k, std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(key_type&& k, Args&&... args) {
+    return rep.try_emplace(std::move(k), std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const_iterator, const key_type& k, Args&&... args) {
+    return rep.try_emplace(k, std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const_iterator, key_type&& k, Args&&... args) {
+    return rep.try_emplace(std::move(k), std::forward<Args>(args)...);
+  }
 
   template <class InputIterator>
   void insert(InputIterator f, InputIterator l) {

--- a/sparsehash/internal/densehashtable.h
+++ b/sparsehash/internal/densehashtable.h
@@ -97,6 +97,7 @@
 #include <memory>     // For uninitialized_fill
 #include <utility>    // for pair
 #include <stdexcept>  // For length_error
+#include <tuple>      // For forward_as_tuple
 #include <type_traits>
 #include <sparsehash/internal/hashtable-common.h>
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
@@ -1049,6 +1050,15 @@ class dense_hashtable {
 
     // here we push key twice as we need it once for the indexing, and the rest of the params are for the emplace itself
     return insert_noresize(std::forward<K>(key), std::forward<K>(key), std::forward<Args>(args)...);
+  }
+
+  template <typename K, typename... Args>
+  std::pair<iterator, bool> try_emplace(K&& key, Args&&... args) {
+    resize_delta(1);
+    // here we push key as we need it for the indexing, and the rest of the params are for the emplace itself
+    return insert_noresize(std::forward<K>(key), std::piecewise_construct,
+        std::forward_as_tuple(std::forward<K>(key)),
+        std::forward_as_tuple(std::forward<Args>(args)...));
   }
 
   // When inserting a lot at a time, we specialize on the type of iterator

--- a/tests/hashtable_c11_unittests.cc
+++ b/tests/hashtable_c11_unittests.cc
@@ -605,3 +605,75 @@ TEST(DenseHashMapIfaceTest, Insert)
     h.insert({{11, 110}, {21, 210}, {31, 310}});
     EXPECT_EQ(9ul, h.size());
 }
+
+TEST(DenseHashMapIfaceTest, TryEmplace)
+{
+    dense_hash_map<int, A> h;
+    h.set_empty_key(0);
+
+    // Test: key does not exist; using user-defined constructor with forwarded argument
+    A::reset();
+    auto p = h.try_emplace(10, 100);
+
+    ASSERT_TRUE(p.second);
+    ASSERT_EQ(10, p.first->first);
+    ASSERT_EQ(100, p.first->second);
+    ASSERT_EQ(100, h[10]._i);
+    ASSERT_EQ(0, A::copy_ctor);
+    ASSERT_EQ(0, A::copy_assign);
+    ASSERT_EQ(0, A::move_ctor);
+    ASSERT_EQ(0, A::move_assign);
+
+    // Test: key exists; using forwarded argument
+    A::reset();
+    p = h.try_emplace(10, 101);
+
+    ASSERT_FALSE(p.second);
+    ASSERT_EQ(10, p.first->first);
+    ASSERT_EQ(100, p.first->second);
+    ASSERT_EQ(100, h[10]._i);
+    ASSERT_EQ(0, A::copy_ctor);
+    ASSERT_EQ(0, A::copy_assign);
+    ASSERT_EQ(0, A::move_ctor);
+    ASSERT_EQ(0, A::move_assign);
+
+    // Test: key does not exist; using move constructor
+    A::reset();
+    p = h.try_emplace(20, A(200));
+
+    ASSERT_TRUE(p.second);
+    ASSERT_EQ(20, p.first->first);
+    ASSERT_EQ(200, p.first->second);
+    ASSERT_EQ(h[20]._i, 200);
+    ASSERT_EQ(0, A::copy_ctor);
+    ASSERT_EQ(0, A::copy_assign);
+    ASSERT_EQ(1, A::move_ctor);
+    ASSERT_EQ(0, A::move_assign);
+
+    // Test: key exists; using move constructor
+    A::reset();
+    p = h.try_emplace(20, A(201));
+
+    ASSERT_FALSE(p.second);
+    ASSERT_EQ(20, p.first->first);
+    ASSERT_EQ(200, p.first->second);
+    ASSERT_EQ(h[20]._i, 200);
+    ASSERT_EQ(0, A::copy_ctor);
+    ASSERT_EQ(0, A::copy_assign);
+    ASSERT_EQ(0, A::move_ctor);
+    ASSERT_EQ(0, A::move_assign);
+
+    // Test: key does not exist; using default constructor
+    A::reset();
+    p = h.try_emplace(30);
+
+    ASSERT_TRUE(p.second);
+    ASSERT_EQ(30, p.first->first);
+    ASSERT_EQ(0, p.first->second);
+    ASSERT_EQ(h[30]._i, 0);
+    ASSERT_EQ(0, A::copy_ctor);
+    ASSERT_EQ(0, A::copy_assign);
+    ASSERT_EQ(0, A::move_ctor);
+    ASSERT_EQ(0, A::move_assign);
+}
+


### PR DESCRIPTION
dense_hash_map: add try_emplace method

Currently, the interface of densehashtable::emplace() forbids users from
using std::pair's piecewise_construct constructor. For example, the
following code does not compile:

```c++
dense_hash_map<int, std::string> h;
h.set_empty_key(0);
h.emplace(1, 5, 'a'); // attempt to create the value std::string(5, 'a')
```

Instead, we have to write the following code, which requires an
additional move construction:

```c++
h.emplace(1, std::string(5, 'a')); // must construct value beforehand
```

To solve this issue, add a new densehashtable::try_emplace method.
It does the same thing as densehashtable::emplace, but uses
std::pair's piecewise_construct constructor instead. This has the
added convenience of mirroring the behavior of unordered_map::try_emplace,
making dense_hash_map more of a drop-in replacement for unordered_map.
