### PR TITLE
sparse_hash_map: add emplace and try_emplace

### DIFF
--- a/docs/sparse_hash_map.html
+++ b/docs/sparse_hash_map.html
@@ -1046,6 +1046,84 @@ void insert(InputIterator f, InputIterator l) </pre> <A href="#2">[2]</A>
 
 <TR>
 <TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; emplace(Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>sparse_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>sparse_hash_map</tt>. The element is
+   constructed in-place with the given <tt>args</tt>.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(const key_type&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>sparse_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>sparse_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(key_type&amp;&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>sparse_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>sparse_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(const_iterator hint, const key_type&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>sparse_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>sparse_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
+   <pre>template&lt;class... Args&gt;
+pair&lt;iterator, bool&gt; try_emplace(const_iterator hint, key_type&amp;&amp; k, Args&amp;&amp;... args)</pre>
+</TD>
+<TD VAlign=top>
+   <tt>sparse_hash_map</tt>
+</TD>
+<TD VAlign=top>
+   Inserts a new element into the <tt>sparse_hash_map</tt> with key <tt>k</tt>
+   and value constructed with <tt>args</tt>. Behaves like <tt>emplace</tt>
+   except that the element is constructed using <tt>std::pair</tt>'s
+   <tt>piecewise_construct</tt> constructor.
+</TD>
+</TR>
+
+<TR>
+<TD VAlign=top>
    <tt>void set_deleted_key(const key_type& key)</tt> <A href="#6">[6]</A>
 </TD>
 <TD VAlign=top>

--- a/sparsehash/internal/sparsehashtable.h
+++ b/sparsehash/internal/sparsehashtable.h
@@ -1045,6 +1045,15 @@ class sparse_hashtable {
     return emplace_noresize(std::forward<K>(key), std::forward<Args>(args)...);
   }
 
+  template <typename K, typename... Args>
+  std::pair<iterator, bool> try_emplace(K&& key, Args&&... args) {
+    resize_delta(1);
+    // here we push key as we need it for the indexing, and the rest of the params are for the emplace itself
+    return emplace_noresize(std::piecewise_construct,
+        std::forward_as_tuple(std::forward<K>(key)),
+        std::forward_as_tuple(std::forward<Args>(args)...));
+  }
+
   // When inserting a lot at a time, we specialize on the type of iterator
   template <class InputIterator>
   void insert(InputIterator f, InputIterator l) {

--- a/sparsehash/internal/sparsehashtable.h
+++ b/sparsehash/internal/sparsehashtable.h
@@ -963,6 +963,21 @@ class sparse_hashtable {
     return iterator(this, table.get_iter(pos), table.nonempty_end());
   }
 
+  template <typename K, typename... Args>
+  iterator emplace_at(size_type pos, K&& key, Args&&... args) {
+    if (size() >= max_size()) {
+      throw std::length_error("insert overflow");
+    }
+    if (test_deleted(pos)) {  // just replace if it's been deleted
+      // The set() below will undelete this object.  We just worry about
+      // stats
+      assert(num_deleted > 0);
+      --num_deleted;  // used to be, now it isn't
+    }
+    table.set_inplace(pos, std::forward<K>(key), std::forward<Args>(args)...);
+    return iterator(this, table.get_iter(pos), table.nonempty_end());
+  }
+
   // If you know *this is big enough to hold obj, use this routine
   std::pair<iterator, bool> insert_noresize(const_reference obj) {
     // First, double-check we're not inserting delkey
@@ -976,6 +991,24 @@ class sparse_hashtable {
           false);  // false: we didn't insert
     } else {       // pos.second says where to put it
       return std::pair<iterator, bool>(insert_at(obj, pos.second), true);
+    }
+  }
+
+  template <typename K, typename... Args>
+  std::pair<iterator, bool> emplace_noresize(K&& key, Args&&... args) {
+    // First, double-check we're not inserting delkey
+    assert(
+        (!settings.use_deleted() || !equals(key, key_info.delkey)) &&
+        "Inserting the deleted key");
+    const std::pair<size_type, size_type> pos = find_position(key);
+    if (pos.first != ILLEGAL_BUCKET) {  // object was already there
+      return std::pair<iterator, bool>(
+          iterator(this, table.get_iter(pos.first), table.nonempty_end()),
+          false);  // false: we didn't insert
+    } else {       // pos.second says where to put it
+      return std::pair<iterator, bool>(
+        emplace_at(pos.second, std::forward<K>(key), std::forward<Args>(args)...),
+        true);
     }
   }
 
@@ -1004,6 +1037,12 @@ class sparse_hashtable {
   std::pair<iterator, bool> insert(const_reference obj) {
     resize_delta(1);  // adding an object, grow if need be
     return insert_noresize(obj);
+  }
+
+  template <typename K, typename... Args>
+  std::pair<iterator, bool> emplace(K&& key, Args&&... args) {
+    resize_delta(1);
+    return emplace_noresize(std::forward<K>(key), std::forward<Args>(args)...);
   }
 
   // When inserting a lot at a time, we specialize on the type of iterator

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -285,6 +285,11 @@ class sparse_hash_map {
   }
 
   template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const key_type& k, Args&&... args) {
+    return rep.try_emplace(k, std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
   std::pair<iterator, bool> try_emplace(key_type&& k, Args&&... args) {
     return rep.try_emplace(std::move(k), std::forward<Args>(args)...);
   }

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -284,6 +284,21 @@ class sparse_hash_map {
     return rep.emplace(std::forward<Args>(args)...);
   }
 
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(key_type&& k, Args&&... args) {
+    return rep.try_emplace(std::move(k), std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const_iterator, const key_type& k, Args&&... args) {
+    return rep.try_emplace(k, std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const_iterator, key_type&& k, Args&&... args) {
+    return rep.try_emplace(std::move(k), std::forward<Args>(args)...);
+  }
+
   // Insertion routines
   std::pair<iterator, bool> insert(const value_type& obj) {
     return rep.insert(obj);

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -279,6 +279,11 @@ class sparse_hash_map {
     return rep.equal_range(key);
   }
 
+  template <typename... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) {
+    return rep.emplace(std::forward<Args>(args)...);
+  }
+
   // Insertion routines
   std::pair<iterator, bool> insert(const value_type& obj) {
     return rep.insert(obj);

--- a/sparsehash/sparsetable
+++ b/sparsehash/sparsetable
@@ -1160,8 +1160,8 @@ class sparsegroup {
     return group[offset];
   }
 
-  template <typename K, typename... Args>
-  reference set_inplace(size_type i, K&& key, Args&&... args) {
+  template <typename... Args>
+  reference set_inplace(size_type i, Args&&... args) {
     size_type offset =
         pos_to_offset(bitmap, i);  // where we'll find (or insert)
     if (bmtest(i)) {
@@ -1174,7 +1174,7 @@ class sparsegroup {
     }
     // This does the actual inserting.  Since we made the array using
     // malloc, we use "placement new" to just call the constructor.
-    new (&group[offset]) value_type(std::forward<K>(key), std::forward<Args>(args)...);
+    new (&group[offset]) value_type(std::forward<Args>(args)...);
     return group[offset];
   }
 
@@ -1646,13 +1646,13 @@ class sparsetable {
     return retval;
   }
 
-  template <typename K, typename... Args>
-  reference set_inplace(size_type i, K&& key, Args&&... args) {
+  template <typename... Args>
+  reference set_inplace(size_type i, Args&&... args) {
     assert(i < settings.table_size);
     typename group_type::size_type old_numbuckets =
         which_group(i).num_nonempty();
     reference retval =
-      which_group(i).set_inplace(pos_in_group(i), std::forward<K>(key), std::forward<Args>(args)...);
+      which_group(i).set_inplace(pos_in_group(i), std::forward<Args>(args)...);
     settings.num_buckets += which_group(i).num_nonempty() - old_numbuckets;
     return retval;
   }

--- a/sparsehash/sparsetable
+++ b/sparsehash/sparsetable
@@ -1160,6 +1160,8 @@ class sparsegroup {
     return group[offset];
   }
 
+  // Creates the inserted item in-place, and returns a reference to the inserted item.
+  // TODO: same as set() - handle exceptions from the constructor
   template <typename... Args>
   reference set_inplace(size_type i, Args&&... args) {
     size_type offset =
@@ -1646,6 +1648,7 @@ class sparsetable {
     return retval;
   }
 
+  // Creates the element to be inserted in-place by forwarding its constructor arguments
   template <typename... Args>
   reference set_inplace(size_type i, Args&&... args) {
     assert(i < settings.table_size);

--- a/sparsehash/sparsetable
+++ b/sparsehash/sparsetable
@@ -1160,6 +1160,24 @@ class sparsegroup {
     return group[offset];
   }
 
+  template <typename K, typename... Args>
+  reference set_inplace(size_type i, K&& key, Args&&... args) {
+    size_type offset =
+        pos_to_offset(bitmap, i);  // where we'll find (or insert)
+    if (bmtest(i)) {
+      // Delete the old value, which we're replacing with the new one
+      group[offset].~value_type();
+    } else {
+      set_aux(offset, realloc_and_memmove_ok());
+      ++settings.num_buckets;
+      bmset(i);
+    }
+    // This does the actual inserting.  Since we made the array using
+    // malloc, we use "placement new" to just call the constructor.
+    new (&group[offset]) value_type(std::forward<K>(key), std::forward<Args>(args)...);
+    return group[offset];
+  }
+
   // We let you see if a bucket is non-empty without retrieving it
   bool test(size_type i) const { return bmtest(i) != 0; }
   bool test(iterator pos) const { return bmtest(pos.pos) != 0; }
@@ -1624,6 +1642,17 @@ class sparsetable {
     typename group_type::size_type old_numbuckets =
         which_group(i).num_nonempty();
     reference retval = which_group(i).set(pos_in_group(i), val);
+    settings.num_buckets += which_group(i).num_nonempty() - old_numbuckets;
+    return retval;
+  }
+
+  template <typename K, typename... Args>
+  reference set_inplace(size_type i, K&& key, Args&&... args) {
+    assert(i < settings.table_size);
+    typename group_type::size_type old_numbuckets =
+        which_group(i).num_nonempty();
+    reference retval =
+      which_group(i).set_inplace(pos_in_group(i), std::forward<K>(key), std::forward<Args>(args)...);
     settings.num_buckets += which_group(i).num_nonempty() - old_numbuckets;
     return retval;
   }

--- a/tests/hashtable_c11_unittests.cc
+++ b/tests/hashtable_c11_unittests.cc
@@ -756,6 +756,8 @@ TEST(SparseHashMapIfaceTest, TryEmplace)
 
     // Test: key does not exist; using move constructor
     A::reset();
+    // Clear sparse_hash_map to avoid double-counting from copying existing elements
+    h.clear();
     p = h.try_emplace(20, A(200));
 
     ASSERT_TRUE(p.second);
@@ -782,6 +784,8 @@ TEST(SparseHashMapIfaceTest, TryEmplace)
 
     // Test: key does not exist; using default constructor
     A::reset();
+    // Clear sparse_hash_map to avoid double-counting from copying existing elements
+    h.clear();
     p = h.try_emplace(30);
 
     ASSERT_TRUE(p.second);

--- a/tests/hashtable_c11_unittests.cc
+++ b/tests/hashtable_c11_unittests.cc
@@ -677,3 +677,49 @@ TEST(DenseHashMapIfaceTest, TryEmplace)
     ASSERT_EQ(0, A::move_assign);
 }
 
+TEST(SparseHashMapMoveTest, Emplace)
+{
+    sparse_hash_map<int, int> h;
+
+    auto p = h.emplace(5, 1234);
+    ASSERT_EQ(true, p.second);
+    ASSERT_EQ(5, p.first->first);
+    ASSERT_EQ(1234, p.first->second);
+
+    p = h.emplace(10, 5678);
+    ASSERT_EQ(true, p.second);
+    ASSERT_EQ(10, p.first->first);
+    ASSERT_EQ(5678, p.first->second);
+
+    ASSERT_EQ(2, (int)h.size());
+
+    ASSERT_TRUE(h.emplace(11, 1).second);
+    ASSERT_FALSE(h.emplace(11, 1).second);
+    ASSERT_TRUE(h.emplace(12, 1).second);
+    ASSERT_FALSE(h.emplace(12, 1).second);
+}
+
+TEST(SparseHashMapMoveTest, Emplace_ValueMoveCount)
+{
+    sparse_hash_map<int, A> h;
+
+    A::reset();
+    h.emplace(1, 2);
+
+    ASSERT_EQ(0, A::copy_ctor);
+    ASSERT_EQ(0, A::copy_assign);
+    ASSERT_EQ(0, A::move_ctor);
+    ASSERT_EQ(0, A::move_assign);
+}
+
+TEST(SparseHashMapMoveTest, Emplace_KeyMoveCount)
+{
+    sparse_hash_map<A, int, HashA> h;
+    A::reset();
+    h.emplace(1, 2);
+
+    ASSERT_EQ(0, A::copy_ctor);
+    ASSERT_EQ(0, A::copy_assign);
+    ASSERT_EQ(0, A::move_ctor);
+    ASSERT_EQ(0, A::move_assign);
+}


### PR DESCRIPTION
Continuing off #44, this PR adds `sparse_hash_map::emplace` and `sparse_hash_map::try_emplace`, along with the necessary helper functions. 

The use of `sparse_hash_map::emplace` and `sparse_hash_map::try_emplace` is similar to that of `dense_hash_map` or `std::unordered_map`. `sparse_hash_map::emplace` takes in (key, val) as its parameters, while `sparse_hash_map::try_emplace` takes in (key, arg list for val), for values with contructors that take in > 1 argument. This allows us to avoid making unnecessary calls to the move/copy constructor.

The functions can be used as follows:

```
sparse_hash_map<int, string> hm;
hm.emplace(0, "hello"); // inserts { 0, "hello" } into the sparse_hash_map
hm.emplace(1, 5, 'a'); // inserts { 1, "aaaaa" } into the sparse_hash_map, by calling the string(int, char) constructor
```